### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "pip install pyfiglet"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Run on Repl.it](https://repl.it/badge/github/karannn14/DiceGame)](https://repl.it/github/karannn14/DiceGame)
 # DiceGame


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).